### PR TITLE
Add Dockerfile and instructions for OpenCV container

### DIFF
--- a/opencv-docker-image/Dockerfile
+++ b/opencv-docker-image/Dockerfile
@@ -1,0 +1,53 @@
+FROM thinktopic/cortex-base
+# gives us ubuntu 16.10, CUDA, not sure about CUDNNN, lein, vault
+MAINTAINER ThinkTopic
+
+RUN apt-get update                                && \
+    apt-get install -y -q                            \
+    build-essential ant checkinstall cmake pkg-config yasm gfortran git libjpeg-dev libpng-dev libtiff-dev libavcodec-dev libavformat-dev libswscale-dev libdc1394-22-dev libxine2-dev libv4l-dev libgtk2.0-dev libtbb-dev libatlas-base-dev libmp3lame-dev libtheora-dev libvorbis-dev libxvidcore-dev libopencore-amrnb-dev libopencore-amrwb-dev x264 v4l-utils 
+
+RUN curl -L https://github.com/opencv/opencv/archive/3.3.0.tar.gz|tar xvz 
+ENV OPENCV_SRC_DIR /opencv-3.3.0
+
+RUN pwd
+
+# change dir to simplify build commands:
+WORKDIR ${OPENCV_SRC_DIR}
+
+# so CMake knows to build the Java bindings:
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+# Turned off CUDA support here because it introduced a gcc dependency conflict on my machine and we don't need it for OpenCV
+RUN mkdir build && cd build && cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D WITH_CUDA=OFF ..
+RUN cd build && make -j$(nproc)
+# Turn the .so into a jar so we can install it to local maven later on using localrepo plugin:
+RUN mkdir -p native/linux/x86_64 && cp build/lib/*java*.so native/linux/x86_64/ && jar -cMf opencv-native-330.jar native
+
+
+ENV DIR /usr/src/app
+VOLUME ${DIR}
+
+RUN chmod 777 ${DIR}
+
+# we use the project.clj next to the Dockerfile just to install opencv jars locally, so the
+# container runner's app (in DIR) can access them
+WORKDIR /
+
+ADD profiles.clj.for-docker-use /etc/leiningen/profiles.clj
+ADD install-opencv-jar.sh /install-opencv-jar.sh
+
+ENV LEIN_REPL_HOST "0.0.0.0"
+ENV LEIN_REPL_PORT 6666
+# this is to do with weirdness around the lein install from the base image
+# being specific to the root user
+RUN unset LEIN_HOME
+RUN unset LEIN_JAR
+
+WORKDIR ${DIR}
+ENV HOME ${DIR}
+# this will install opencv for the running user, then open a repl
+# doing the install inside the dockerfile would make it only work for root
+# doing it on run allows for us to run the container as a non superuser
+# contrary to my expectations, there's no way of having a system-wide, local maven repo AND a user-specific one
+ENTRYPOINT ["bash", "/install-opencv-jar.sh"]
+
+

--- a/opencv-docker-image/README.md
+++ b/opencv-docker-image/README.md
@@ -1,0 +1,71 @@
+# ThinkTopic's OpenCV image
+
+## What is this for?
+
+If you want to quickly do useful things involving Clojure, Cortex and OpenCV, this is your best bet, especially if you have plans to have an easy transition from your dev workflow to production.
+
+This directory contains everything needed to build thinktopic/opencv-cortex, an image based on [`thinktopic/cortex-base`](https://github.com/thinktopic/cortex/blob/master/scripts/Dockerfile.cortex-base).
+
+## Features
+
+*  OpenCV 3.3.0, compiled with ffmpeg, Java bindings and most optional dependencies.
+*  The same Ubuntu / CUDA / Cortex setup as a lot of our machine learning projects
+*  Can run it in any lein project, and it'll spin up a REPL with access to your repo's dir, with OpenCV support that works without needing to change any of your dependencies, etc.
+*  Runs as your current user, not root, so you don't end up with bizarre issues with files in your repo that you can't modify
+*  Keeps a cache of its own maven dependencies in the app dir, so it doesn't interfere with your own ~/.m2
+*  By default it starts a REPL for your project, bound locally on a fixed port
+
+## How to use
+
+Run this from within the root dir of your leiningen app:
+
+```clj
+docker pull docker.thinktopic.com/opencv-cortex
+docker run --rm -u (id -u):(id -g) -i -t -v (pwd):/usr/src/app -p 6666:6666 --name cv-repl thinktopic/opencv-cortex
+```
+
+You should be greeted with a REPL. You can connect more sessions to the REPL like this:
+
+```
+lein repl :connect 0.0.0.0:6666
+```
+
+Or however you so choose. You can also just use the REPL you attach to by default when you do Docker run.
+
+If something goes wrong, file an issue here or just ping Alistair.
+
+### Trying OpenCV out
+
+Try running this at the REPL, after adding "sample-video.mp4" to the root of your repo:
+
+```clj
+(clojure.lang.RT/loadLibrary org.opencv.core.Core/NATIVE_LIBRARY_NAME)
+(import '(org.opencv.videoio VideoCapture))
+(import '(org.opencv.core Point Mat))
+(import '(org.opencv.imgcodecs Imgcodecs))
+
+(def vc
+  (VideoCapture. "sample-video.mp4"))
+
+(def output
+  (Mat.))
+
+(assert (.isOpened vc))
+
+(.read vc output)
+
+(assert (not (.empty output)))
+
+(Imgcodecs/imwrite "first_frame_of_video.jpg" output)
+```
+
+## Rough edges
+
+*  The local maven repo for the container is stored in a directory called "?". Fixing this is a matter of including a settings.xml file (for maven) in the Dockerfile, in the user's home directory.
+
+## Building
+
+```
+docker build . -t thinktopic/opencv-cortex
+```
+

--- a/opencv-docker-image/README.md
+++ b/opencv-docker-image/README.md
@@ -4,13 +4,13 @@
 
 If you want to quickly do useful things involving Clojure, Cortex and OpenCV, this is your best bet, especially if you have plans to have an easy transition from your dev workflow to production.
 
-This directory contains everything needed to build thinktopic/opencv-cortex, an image based on [`thinktopic/cortex-base`](https://github.com/thinktopic/cortex/blob/master/scripts/Dockerfile.cortex-base).
+This directory contains everything needed to build `thinktopic/opencv-cortex`, an image based on [`thinktopic/cortex-base`](https://github.com/thinktopic/cortex/blob/master/scripts/Dockerfile.cortex-base).
 
 ## Features
 
 *  OpenCV 3.3.0, compiled with ffmpeg, Java bindings and most optional dependencies.
 *  The same Ubuntu / CUDA / Cortex setup as a lot of our machine learning projects
-*  Can run it in any lein project, and it'll spin up a REPL with access to your repo's dir, with OpenCV support that works without needing to change any of your dependencies, etc.
+*  Can run it in any lein project, and it'll spin up a REPL (using *your* `project.clj`) with access to your repo's dir, with OpenCV support that works without needing to change any of your dependencies, etc.
 *  Runs as your current user, not root, so you don't end up with bizarre issues with files in your repo that you can't modify
 *  Keeps a cache of its own maven dependencies in the app dir, so it doesn't interfere with your own ~/.m2
 *  By default it starts a REPL for your project, bound locally on a fixed port

--- a/opencv-docker-image/install-opencv-jar.sh
+++ b/opencv-docker-image/install-opencv-jar.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+env
+lein with-profile -user localrepo install /opencv-3.3.0/build/bin/opencv-330.jar thinktopic/opencv-java 3.3.0
+echo "don't worry, there's no error, lein's just being dumb"
+lein with-profile -user localrepo install /opencv-3.3.0/opencv-native-330.jar thinktopic/opencv-java-native 3.3.0
+echo "don't worry, there's no error, lein's just being dumb"
+lein repl

--- a/opencv-docker-image/profiles.clj.for-docker-use
+++ b/opencv-docker-image/profiles.clj.for-docker-use
@@ -1,0 +1,7 @@
+{:system {:plugins [[lein-localrepo "0.5.4"]]}
+  :user {
+        :dependencies [
+                 [thinktopic/opencv-java "3.3.0"]
+                 [thinktopic/opencv-java-native "3.3.0"]]
+        }}
+


### PR DESCRIPTION
Check out [the README](https://github.com/thinktopic/think.image/blob/fcfaf255ef6f662880cdd5f9dd1d7dc69c9c949d/opencv-docker-image/README.md), there's a pretty detailed explanation about why this exists and how to use it.